### PR TITLE
Automatic retries on failure

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,5 +10,5 @@ The current version support matrix appears below.
 
 ## Reporting a Vulnerability
 
-To report a security vulnerability, e-maiil security at babybritain dot ltd.
+To report a security vulnerability, e-mail security at babybritain dot ltd.
 Any and all reports will be responded to promptly.

--- a/package-lock.json
+++ b/package-lock.json
@@ -294,6 +294,7 @@
             "has": "^1.0.3",
             "has-symbols": "^1.0.1",
             "is-callable": "^1.2.2",
+            "is-negative-zero": "^2.0.0",
             "is-regex": "^1.1.1",
             "object-inspect": "^1.8.0",
             "object-keys": "^1.1.1",
@@ -308,8 +309,30 @@
           "integrity": "sha512-VT/cxmx5yaoHSOTSyrCygIDFco+RsibY2NM0a4RdEeY/4KgqezwFtK1yr3U67xYhqJSlASm2pKhLVzPj2lr4bA==",
           "requires": {
             "define-properties": "^1.1.3",
+            "es-abstract": "^1.18.0-next.0",
             "has-symbols": "^1.0.1",
             "object-keys": "^1.1.1"
+          },
+          "dependencies": {
+            "es-abstract": {
+              "version": "1.18.0-next.1",
+              "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+              "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+              "requires": {
+                "es-to-primitive": "^1.2.1",
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3",
+                "has-symbols": "^1.0.1",
+                "is-callable": "^1.2.2",
+                "is-negative-zero": "^2.0.0",
+                "is-regex": "^1.1.1",
+                "object-inspect": "^1.8.0",
+                "object-keys": "^1.1.1",
+                "object.assign": "^4.1.1",
+                "string.prototype.trimend": "^1.0.1",
+                "string.prototype.trimstart": "^1.0.1"
+              }
+            }
           }
         }
       }
@@ -539,6 +562,11 @@
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.1.tgz",
       "integrity": "sha512-T/S49scO8plUiAOA2DBTBG3JHpn1yiw0kRp6dgiZ0v2/6twi5eiB0rHtHFH9ZIrvlWc6+4O+m4zg5+Z833aXgw==",
       "dev": true
+    },
+    "is-negative-zero": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.0.tgz",
+      "integrity": "sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE="
     },
     "is-number": {
       "version": "7.0.0",

--- a/src/client.js
+++ b/src/client.js
@@ -408,8 +408,8 @@ const Client = class extends Base {
           throw new Error("retry attemps exceeded");
         }
         consecutive_errors += 1;
-        this._io.log('warning', `An error occurred while performing network request (attempt ${consecutive_errors}/3): ${err}`);
-        this._io.log('warning', `Trying again...`);
+        this._io.warn(`An error occurred while performing network request (attempt ${consecutive_errors}/3): ${err}`);
+        this._io.warn(`Trying again...`);
         continue;
       }
       consecutive_errors = 0;

--- a/src/client.js
+++ b/src/client.js
@@ -392,13 +392,27 @@ const Client = class extends Base {
       throw new Error('Result dispatch: start failed');
     }
 
+    let consecutive_errors = 0;
+
     for (;;) {
 
       /* Fail closed */
       let key_comparison = 0;
 
       /* Perform actual network request */
-      let record = await _request_callback(_profile, next_key);
+      let record = null;
+      try {
+        record = await _request_callback(_profile, next_key);
+      } catch(err) {
+        if (consecutive_errors > 3) {
+          throw new Error("retry attemps exceeded");
+        }
+        consecutive_errors += 1;
+        this._io.log('warning', `An error occurred while performing network request (attempt ${consecutive_errors}/3): ${err}`);
+        this._io.log('warning', `Trying again...`);
+        continue;
+      }
+      consecutive_errors = 0;
       next_key = record.next;
 
       /* Extract result array */


### PR DESCRIPTION
This small PR adds automatic retries (up to three times) on failure in `_paged_request`. Often, when I'm scraping a popular tag, I run into an error after about two minutes of scraping (around 25-50 pages). An immediate retry usually works; automatic retries seem like a great way to improve the robustness of the tool (and avoid having to restart searches from scratch).

I'm happy to implement the retry logic differently/elsewhere if you prefer. I'm also happy to make the retry amount configurable (right now it's fixed at 3) if you think that would be valuable.